### PR TITLE
fix: continue in case `gpg` is missing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,6 +132,7 @@ runs:
 
     - name: Import GPG key for zon-ops user
       uses: crazy-max/ghaction-import-gpg@v5
+      continue-on-error: true
       with:
         gpg_private_key: ${{ steps.zon-ops-gpg.outputs.gpg_key_private }}
         git_user_signingkey: true


### PR DESCRIPTION
This is especially useful for workflows that use a custom (base) image, in particular for our 'nightwatch' runners.