### PR TITLE
Configure zon-ops as the user for all git checkouts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,7 @@ runs:
         git_user_signingkey: true
         git_commit_gpgsign: true
         # git_tag_gpgsign: true
+        git_config_global: true
 
     - name: GCloud OIDC Auth
       id: auth


### PR DESCRIPTION
Das hilft zb [hier](https://github.com/ZeitOnline/friedbert-deployment/blob/master/.github/workflows/do-release.yaml#L22-L36), wo wir in `friedbert-deployment` "sitzen", aber zusätzlich `zeit.web` auschecken, und dann _darin_ was committen wollen.