### PR TITLE
Revert "fix(vault): increase token TTL"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -204,7 +204,6 @@ runs:
         role: ${{ steps.baseproject-config.outputs.gha_vault_role }}-${{ steps.repo_without_slash.outputs.result }}
         exportToken: true
         secrets: sys/auth "token/" # Because the action needs to read something and Token auth is always there
-        jwtTtl: 7200 # 2 hour, for extra long running workflows
 
     - id: vault_token
       run: echo "vault_token=$(echo $VAULT_TOKEN)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
setting jwtTtl has no effect when using default GHA token. TTL has to be set in the vault backend role

This reverts commit 5360444baebcaec5e5d5cfca0e45a2674473b476.