### PR TITLE
feat: export gcloud access token as env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -210,7 +210,7 @@ runs:
         secrets: sys/auth "token/" # Because the action needs to read something and Token auth is always there
 
     - id: vault_token
-      run: echo "vault_token=$(echo $VAULT_TOKEN)" >> $GITHUB_OUTPUT
+      run: echo "vault_token=$VAULT_TOKEN" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Setup Python Artifact Registry

--- a/action.yml
+++ b/action.yml
@@ -237,7 +237,7 @@ runs:
           debug = true
           [registry."docker.io"]
             mirrors = ["https://mirror.gcr.io"]
-    # Support `docker buildx build --cache-[from}to] type=gha` directly,
+    # Support `docker buildx build --cache-[from|to] type=gha` directly,
     # and not just via docker/build-push-action.
     - name: Setup docker buildx environment
       if: env.setup_buildx == 'true'

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,9 @@ runs:
       id: output_gcloud_token
       if: steps.auth.outputs.access_token != ''
       shell: bash
-      run: echo "gcloud_access_token=${{ steps.auth.outputs.access_token }}" >> $GITHUB_OUTPUT
+      run: |
+        echo "gcloud_access_token=${{ steps.auth.outputs.access_token }}" >> $GITHUB_OUTPUT
+        echo "GCLOUD_TOKEN=${{ steps.auth.outputs.access_token }}" >> $GITHUB_ENV
 
     - name: Write GKE Credentials to kubeconfig
       if: inputs.gke_auth == 'true'


### PR DESCRIPTION
This allows using the value e.g. in shell-based contexts. The naming is inspired by `VAULT_TOKEN`.

My initial use case is configuring GAR `pypi-zon` access directly, without the (somewhat cumbersome) intermediate `keyrings.google-artifactregistry-auth` package, see https://github.com/ZeitOnline/www-gone/pull/354