### PR TITLE
feat: add audience claim to jwt sent to vault

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -156,6 +156,7 @@ runs:
         method: jwt
         path: github-actions
         role: gha-baseproject
+        jwtGithubAudience: vault
         secrets: |
           ${{ steps.vault_path.outputs.result }}/infos-k8s-${{ inputs.gke_cluster }} raw | INFOS_K8S;
 


### PR DESCRIPTION
Another instance of "Vault wants aud claims nowadays". This is Step 1 of 2: Request an aud claim. Step 2 is to require the aud claim in [this Vault Role ](https://github.com/ZeitOnline/vault/blob/37488e26dd825f8197d52f210cef8ff71716bede/terraform/modules/zon-vault/github-actions.tf#L149) once all instances of this actions are updated.