### PR TITLE
fix(gha): report missing baseproject config clearly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,30 @@ runs:
         secrets: |
           ${{ steps.vault_path.outputs.result }}/infos raw | INFOS;
 
-    - id: baseproject-config
+    - name: Explain a missing Baseproject config
+      if: failure() && steps.raw-config.outcome == 'failure'
+      shell: bash
+      run: |
+        path="${{ steps.vault_path.outputs.result }}/infos"
+        echo "::error::No baseproject config readable at '$path'. Either the Terraform baseproject instance for project '${{ inputs.project_name }}' (environment '${{ inputs.environment }}') was never applied, or the unique_id input is missing, or the gha-baseproject Vault role has no access to that path."
+        {
+          echo "## ❌ Baseproject config not found in Vault"
+          echo ""
+          echo "The action could not read \`$path\`."
+          echo ""
+          echo "Checklist:"
+          echo "- Is the \`baseproject\` Terraform instance for project \`${{ inputs.project_name }}\` applied for environment \`${{ inputs.environment }}\`?"
+          echo "- Does that instance use a \`unique_id\`? If so, pass it via the \`unique_id\` input (currently \`${{ inputs.unique_id }}\`)."
+          echo "- Does the \`gha-baseproject\` Vault role grant read access to the path?"
+        } >> $GITHUB_STEP_SUMMARY
+
+    # NOTE: needs an explicit `name`. Without one the runner derives the display name from
+    # the `run` script and renders it for every step, whether or not the step runs — so an
+    # empty `INFOS` makes fromJSON('') log "Encountered an error when evaluating display
+    # name … Error reading JToken from JsonReader". That is only a warning, never fatal,
+    # but it is prominent enough to be mistaken for the actual error.
+    - name: Set Baseproject Config outputs
+      id: baseproject-config
       shell: bash
       # Right now this is the only known way to pass outputs from a JSON value as outputs from
       # a composite action (hypothesis: between here and any outputs.xy.value, some JSON auto-
@@ -170,14 +193,20 @@ runs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Note:** The secret is only created if \`ci_sa_is_namespace_admin\` is set in your baseproject_k8s instance." >> $GITHUB_STEP_SUMMARY
 
-    - id: baseproject-config-k8s
+    # NOTE: needs an explicit `name`, same reason as `baseproject-config` above. This one
+    # warned on every single call with `gke_auth: false`, because `raw-config-k8s` is then
+    # skipped and its output is empty. The `|| '{}'` fallbacks keep the template valid for
+    # that rendering; they do not affect the executed script, which only runs once the `if`
+    # below has confirmed a non-empty value.
+    - name: Set Baseproject K8S Config outputs
+      id: baseproject-config-k8s
       if: inputs.gke_auth == 'true' && steps.raw-config-k8s.outputs.INFOS_K8S != ''
       shell: bash
       run: |
-        echo "namespace"=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S).namespace }} >> $GITHUB_OUTPUT
-        echo "cluster_name"=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S).cluster-name }} >> $GITHUB_OUTPUT
-        echo "cluster_project"=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S).cluster-project }} >> $GITHUB_OUTPUT
-        echo "cluster_location"=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S).cluster-location }} >> $GITHUB_OUTPUT
+        echo "namespace=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S || '{}').namespace }}" >> $GITHUB_OUTPUT
+        echo "cluster_name=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S || '{}').cluster-name }}" >> $GITHUB_OUTPUT
+        echo "cluster_project=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S || '{}').cluster-project }}" >> $GITHUB_OUTPUT
+        echo "cluster_location=${{ fromJSON(steps.raw-config-k8s.outputs.INFOS_K8S || '{}').cluster-location }}" >> $GITHUB_OUTPUT
 
     - name: Retrieve zon-ops GitHub user GPG key
       id: zon-ops-gpg
@@ -224,7 +253,8 @@ runs:
         project_id: ${{ steps.baseproject-config-k8s.outputs.cluster_project }}
         location: ${{ steps.baseproject-config-k8s.outputs.cluster_location }}
 
-    - if: inputs.gke_auth == 'true'
+    - name: Set kubectl context namespace
+      if: inputs.gke_auth == 'true' && steps.baseproject-config-k8s.outputs.namespace != ''
       shell: bash
       run: kubectl config set-context --current --namespace=${{ steps.baseproject-config-k8s.outputs.namespace }}
 
@@ -284,8 +314,16 @@ runs:
       if: env.setup_buildx == 'true'
       uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
 
+    # The Slack token comes from `slack-token-vault`, which is itself skipped when an
+    # earlier step failed. Without this guard the reporter then fails with "Missing input!
+    # A token must be provided", which becomes the job's last error and masks the real one.
+    - name: Warn about a skipped status report
+      if: ${{ (failure() || github.workflow == 'Self-Surveillance Check') && steps.slack-token-vault.outputs.NOTIFIER_TOKEN == '' }}
+      shell: bash
+      run: echo "::warning::No Slack token available (the token step did not run), skipping the status report to ${{ inputs.alerting_channel }}."
+
     - name: Report Status
-      if: ${{failure() || github.workflow == 'Self-Surveillance Check'}}
+      if: ${{ (failure() || github.workflow == 'Self-Surveillance Check') && steps.slack-token-vault.outputs.NOTIFIER_TOKEN != '' }}
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       with:
         method: chat.postMessage


### PR DESCRIPTION
## Problem

A missing baseproject secret in Vault produced three confusing messages instead of one clear error. Traced through three real runs:

| Run | Symptom |
| --- | --- |
| [zeit.k8stesting #31010277000](https://github.com/ZeitOnline/zeit.k8stesting/actions/runs/31010277000/job/92320378550) | real Vault 404, buried under two `display name` warnings and a bogus Slack error |
| [atlantis-deployment #31078296471](https://github.com/ZeitOnline/atlantis-deployment/actions/runs/31078296471) | **green** run, still logs the `display name` warning |
| this repo's own Self-Surveillance Check [#30453482602](https://github.com/ZeitOnline/gh-action-baseproject/actions/runs/30453482602) | **green**, same warning — it has been there all along |

### 1. `Encountered an error when evaluating display name`

Steps without a `name` get their display name derived from their `run` script. The runner renders that for **every** step, including skipped ones, so an empty step output makes `fromJSON('')` fail:

```
##[warning]Encountered an error when evaluating display name ${{ format('echo "namespace"={0} …
The template is not valid. ZeitOnline/gh-action-baseproject/v0/action.yml (Line: 176, Col: 12):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

It is only a `##[warning]` and never fails a job, but it reads like the actual failure. It fires on **every** call with `gke_auth: false`, since `raw-config-k8s` is skipped then and its output is empty.

Both affected steps now carry an explicit `name`. The k8s step additionally falls back to `{}` so the rendered template stays valid regardless.

### 2. `Missing input! A token must be provided`

`Report Status` runs on `failure()`, but its Slack token comes from `slack-token-vault`, which is itself skipped once an earlier step failed. The reporter then failed, became the job's *last* error — masking the real one — and sent no alert either way.

It now requires a non-empty token, and a preceding step logs `::warning::` when the report is skipped, so a missing alert stays visible.

### 3. The actual error was under-explained

A missing secret surfaced only as vault-action's 404. A new step names the exact path and writes a checklist to the job summary: Terraform instance not applied, `unique_id` missing, or the `gha-baseproject` Vault role lacking read access.

## Also

Guards `kubectl config set-context` against an empty namespace — the failing run shows it as `Run kubectl config set-context --current --namespace=`.

## Verification

`actionlint` 1.7.12 at full strength (shellcheck + pyflakes enabled), exit 0.

## Not included

- `raw-config-k8s` has `ignoreNotFound: false`, so a missing k8s secret fails the step rather than yielding an empty output. That makes the existing `Warning for missing K8s config` step unreachable. Fixing it needs a fail-fast guard before `get-gke-credentials` in the same change.
- With an empty `unique_id` the Vault path gets a double slash (`…/production//infos`). Vault normalizes it, so it is cosmetic, but it makes error messages look like a path bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)