### PR TITLE
ci: lint workflows with actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint only knows the GitHub-hosted runner labels and errors on any other
+# `runs-on:`. This declares the ZON self-hosted scale sets, same list as the
+# default in ZeitOnline/gh-action-workflows-ops.
+self-hosted-runner:
+  labels:
+    - zon-ubuntu-general-dind
+    - zon-ubuntu-general-dind-devel
+    - zon-ubuntu-general-k8s
+    - zon-ubuntu-general-k8s-devel

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -1,0 +1,45 @@
+name: CI Lint
+
+# Static analysis for this repo's GitHub Actions files, mirroring
+# `lint-workflows.yaml` in ZeitOnline/gh-action-workflows-ops.
+#
+# Kept self-contained instead of calling that reusable workflow: this repo is
+# public, gh-action-workflows-ops is private, and a public repo calling a private
+# repo's reusable workflow is not a pattern we have confirmed. A local job has no
+# cross-repo dependency and cannot break when that repo's Actions access setting
+# changes.
+#
+# actionlint also validates `action.yml` itself, because `pr-checks.yaml` calls
+# the action via `uses: ./` — the inputs used there are checked against the
+# action's declared inputs.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  checks: write # required by reviewdog's github-pr-check reporter
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: zon-ubuntu-general-dind
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # nothing here talks to git after checkout; actionlint reads the tree and
+          # reviewdog authenticates through its own token input
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e # v1.73.0
+        with:
+          reporter: github-pr-check
+          # lint every workflow, not just the ones the PR touches
+          filter_mode: nofilter
+          level: error
+          fail_level: error
+          # the shellcheck and pyflakes integrations flag findings in every `run:`
+          # block that was never linted before; drop the flags for full strength
+          actionlint_flags: '-shellcheck= -pyflakes='


### PR DESCRIPTION
## What

Adds an `actionlint` status check for this repo's GitHub Actions workflows, mirroring [`lint-workflows.yaml`](https://github.com/ZeitOnline/gh-action-workflows-ops/blob/main/.github/workflows/lint-workflows.yaml) from `ZeitOnline/gh-action-workflows-ops` — same action pins, same reporter, same flags.

## Why self-contained instead of calling the reusable workflow

`gh-action-workflows-ops` is **private** (workflow access `organization`), this repo is **public**. The REST docs state only that *"organization level access allows sharing across the organization"* and that the setting "only applies to private repositories" — they do not say whether a public repo may call a private repo's reusable workflow, and no repo currently does it, so there is no working precedent to copy. A local job has no cross-repo dependency and cannot break if that repo's access setting changes.

## Why it matters beyond linting

[`renovate.json`](../blob/main/renovate.json) automerges `minor`/`patch`/`digest` action updates. Renovate waits for a passing status check before merging; without one it waits indefinitely.

## `.github/actionlint.yaml`

Declares the ZON self-hosted runner labels. Verified: without this file actionlint fails **every** `runs-on:` in the repo with `label "zon-ubuntu-general-dind" is unknown`.

## Coverage limit

actionlint only lints `.github/workflows/*`. `action.yml` is read as *action metadata*, so the inputs used at the `uses: ./` call sites in `pr-checks.yaml` and `self-surveillance-check.yaml` are validated — but its own `run` blocks and expressions are not. Passing it explicitly does not help; actionlint parses it as a workflow and reports `"jobs" section is missing`.

Concretely: this check would **not** have caught the bug fixed in #165.

## Verification

Ran the exact image the action uses (`ghcr.io/reviewdog/action-actionlint@sha256:05f22f70…`, actionlint 1.7.12) against the tree:

| Run | Result |
| --- | --- |
| `actionlint -shellcheck= -pyflakes=` (as configured) | 0 errors in 4 files |
| `actionlint` (full strength) | 0 errors |
| without `.github/actionlint.yaml` | 4 errors, exit 1 |

Full strength passes too, so `actionlint_flags: ''` is an option if we want shellcheck over `run:` blocks from the start. Kept the ops-repo default for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)